### PR TITLE
fixed issue where haproxy does not reload when config changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ADD haproxy.ctmpl /haproxy.ctmpl
 EXPOSE 80
 
 ENTRYPOINT ["/consul-template"]
-CMD ["-consul", "consul:8500", "-template", "/haproxy.ctmpl:/etc/haproxy/haproxy.cfg:service haproxy restart"]
+CMD ["-consul", "consul:8500", "-template", "/haproxy.ctmpl:/etc/haproxy/haproxy.cfg:service haproxy reload"]


### PR DESCRIPTION
The restart command fails because the 'kill' command is missing. However, reload is also available and does everything we need. 
